### PR TITLE
Add Pytest tests for API and sensor functionality

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,26 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from custom_components.miwifi_cb0401v2.api import MiWiFiClient
+
+@pytest.fixture
+def client():
+    session = AsyncMock()
+    return MiWiFiClient("192.168.31.1", "admin", "password", session)
+
+@pytest.mark.asyncio
+async def test_login(client):
+    with patch("custom_components.miwifi_cb0401v2.api.aiohttp.ClientSession.post") as mock_post:
+        mock_post.return_value.__aenter__.return_value.status = 200
+        mock_post.return_value.__aenter__.return_value.json = AsyncMock(return_value={"token": "test_token"})
+        success = await client.login()
+        assert success
+        assert client._token == "test_token"
+
+@pytest.mark.asyncio
+async def test_fetch_mac_address(client):
+    client._token = "test_token"
+    with patch("custom_components.miwifi_cb0401v2.api.aiohttp.ClientSession.get") as mock_get:
+        mock_get.return_value.__aenter__.return_value.status = 200
+        mock_get.return_value.__aenter__.return_value.json = AsyncMock(return_value={"hardware": {"mac": "00:11:22:33:44:55"}})
+        mac_address = await client.fetch_mac_address()
+        assert mac_address == "00:11:22:33:44:55"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,16 @@
+import pytest
+from unittest.mock import AsyncMock
+from custom_components.miwifi_cb0401v2.sensor import BaseMiWiFiSensor
+
+@pytest.fixture
+def sensor():
+    client = AsyncMock()
+    client.mac_address = "00:11:22:33:44:55"
+    return BaseMiWiFiSensor(client, "net.info.cell_band", "Cell Band Sensor")
+
+@pytest.mark.asyncio
+async def test_sensor_update(sensor):
+    sensor._client.cpe_detect = AsyncMock(return_value={"net": {"info": {"cell_band": "B3"}}})
+    await sensor.async_update()
+    assert sensor.state == "B3"
+    assert sensor.available

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -14,3 +14,8 @@ async def test_sensor_update(sensor):
     await sensor.async_update()
     assert sensor.state == "B3"
     assert sensor.available
+    assert sensor.name == "Cell Band Sensor"
+    assert sensor.unique_id == "net.info.cell_band"
+    sensor._client.cpe_detect = AsyncMock(side_effect=ConnectionError)
+    await sensor.async_update()
+    assert not sensor.available


### PR DESCRIPTION
## Zusammenfassung von Sourcery

Einführung von Pytest-Tests für API- und Sensorkomponenten zur Sicherstellung der Funktionalität und Zuverlässigkeit.

Tests:
- Hinzufügen von Pytest-Tests für die MiWiFiClient-API-Funktionalität, einschließlich Login und Abrufen von MAC-Adressen.
- Hinzufügen von Pytest-Tests für die Funktionalität von BaseMiWiFiSensor, mit Fokus auf Sensorstatusaktualisierungen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce Pytest tests for API and sensor components to ensure functionality and reliability.

Tests:
- Add Pytest tests for MiWiFiClient API functionality, including login and MAC address fetching.
- Add Pytest tests for BaseMiWiFiSensor functionality, focusing on sensor state updates.

</details>